### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/DomainTestService.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/DomainTestService.java
@@ -22,8 +22,8 @@ public class DomainTestService {
     }
 
     try {
-      //TODO use ProcessBuilder which looks cleaner
-      Process process = Runtime.getRuntime().exec(new String[] {"sh", "-c", "ping -c 1 " + domainName});
+      ProcessBuilder processBuilder = new ProcessBuilder("ping", "-c", "1", domainName);
+      Process process = processBuilder.start();
       if (!process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)) {
         throw new UnableToTestDomainException("Timed out pinging domain");
       }


### PR DESCRIPTION
Fixes [https://github.com/sreejithinfysec/java1/security/code-scanning/1](https://github.com/sreejithinfysec/java1/security/code-scanning/1)

To fix the problem, we should avoid directly passing user input to the `Runtime.exec` method. Instead, we can use the `ProcessBuilder` class, which provides a safer way to execute system commands by separating the command and its arguments. This approach avoids the need to concatenate strings and reduces the risk of command injection.

1. Replace the `Runtime.getRuntime().exec` call with `ProcessBuilder`.
2. Pass the domain name as an argument to the `ping` command without concatenating it into a single string.
3. Ensure that the `ProcessBuilder` is used correctly to handle the command and its arguments separately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
